### PR TITLE
fix syntax error problem from stray byte

### DIFF
--- a/dtwco/warping/_deprecated.py
+++ b/dtwco/warping/_deprecated.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from dtwco._c import dtw as _c
 from dtwco.warping.core import dtw
 import warnings

--- a/dtwco/warping/core.py
+++ b/dtwco/warping/core.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from dtwco._c import dtw as _c
 
 def dtw(x, y, dist_only=True, metric='euclidean', constraint=None, k=None, warping_penalty=0):


### PR DESCRIPTION
There was a stray byte somewhere in these two files giving me the error

`SyntaxError: Non-ASCII character '\xe2' in file dtwco/warping/_deprecated.py on line 43, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details`

So I just added a few lines to fix this